### PR TITLE
Fix for Dockerfile smell DL3003

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR $PROJECT_ROOT
 RUN curl -sSL https://github.com/dyweb/dy-weekly-generator/releases/download/$WEEKLY_GEN_VERSION/dy-weekly-generator-$WEEKLY_GEN_VERSION-x86_64-unknown-linux-gnu.tar.gz \
        | tar -vxz -C /usr/bin
 COPY . $PROJECT_ROOT
-RUN cd scripts/weekly && go install .
+WORKDIR scripts/weekly 
+RUN  go install .
 
 # Runner
 FROM ubuntu:18.04


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3003 occurs if the pattern `RUN cd ...` is used to change directories instead of the dedicated WORKDIR instruction.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the pattern `RUN cd ...` is replaced with the equivalent WORKDIR instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance